### PR TITLE
Fileutilsを削除

### DIFF
--- a/app/controllers/moca_data_controller.rb
+++ b/app/controllers/moca_data_controller.rb
@@ -4,7 +4,6 @@ require 'google/apis/drive_v3'
 require 'google/api_client/client_secrets'
 require 'csv'
 require 'roo'
-require 'Fileutils'
 
 class MocaDataController < ApplicationController
   # ファイルをアップロード


### PR DESCRIPTION
LoadError (cannot load such file -- Fileutils):
モジュール名`Fileutils`が間違っているためにエラーになった。　　
現状使ってないので削除する。